### PR TITLE
fixed configurations to use latest dotnet runtime, updated the librar…

### DIFF
--- a/src/dotNetSMB/WriteFiles.cs
+++ b/src/dotNetSMB/WriteFiles.cs
@@ -171,7 +171,7 @@ namespace lambda_smb_dotnet
             SecretJSON secretJSON = JsonSerializer.Deserialize<SecretJSON>(secretValue);
 
             SMB2Client client = new SMB2Client();
-            bool isConnected = client.Connect(IPAddress.Parse(secretJSON.host), SMBTransportType.DirectTCPTransport); // Attempt connecting to SMB share
+            bool isConnected = client.Connect(secretJSON.host, SMBTransportType.DirectTCPTransport); // Attempt connecting to SMB share
 
             if (isConnected)
             {

--- a/src/dotNetSMB/lambda-smb-dotnet.csproj
+++ b/src/dotNetSMB/lambda-smb-dotnet.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.*" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
-    <PackageReference Include="SMBLibrary" Version="1.4.6.1" />
+    <PackageReference Include="SMBLibrary" Version="1.4.8" />
     <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
…y, fixed the code to use hostname instead of ip address

*Issue #, if available:* old code using a deprecated dotnet runtime and the code does not work as it uses ip address instead of host

*Description of changes:*
updated the runtime and code to make it work with current lambda runtime


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
